### PR TITLE
Fix systemd start option and add configurable logging drivers

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This Ansible role allows users thereof to install the [AWS ECS Agent](https://gi
 
 ## Requirements
 
-* Ansible 2.2+
+* Ansible 2.5+
 * Tested on Ubuntu 14.04, 16.04 and 18.04
 
 ## Role Variables
@@ -21,6 +21,7 @@ Please consult http://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-ag
 * `ubuntu_ecs_agent_container_stop_timeout`: `ECS_CONTAINER_STOP_TIMEOUT` (Default: 30s)
 * `ubuntu_ecs_agent_auth_type`: `ECS_ENGINE_AUTH_TYPE` (Default: "")
 * `ubuntu_ecs_agent_auth_data`: `ECS_ENGINE_AUTH_DATA` (Default: "")
+* `ubuntu_ecs_agent_start_mode`: Set to "docker" or "systemd", depending how you would like to start the agent container (Default: "docker")
 
 ## Dependencies
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,9 +5,11 @@
 ubuntu_ecs_agent_data_path: /data
 ubuntu_ecs_agent_loglevel: info
 ubuntu_ecs_agent_cluster_name: default
+ubuntu_ecs_agent_logging_drivers: ["json-file","awslogs"]
 ubuntu_ecs_agent_enable_iam_role: true
 ubuntu_ecs_agent_enable_task_iam_role_network_host: true
 ubuntu_ecs_agent_reserved_ports: [22, 2375, 2376, 51678]
 ubuntu_ecs_agent_container_stop_timeout: 30s
 ubuntu_ecs_agent_auth_type: ""
 ubuntu_ecs_agent_auth_data: ""
+ubuntu_ecs_agent_start_mode: "docker"

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -2,7 +2,7 @@ galaxy_info:
   author: Johan Meiring
   description: "Deploy AWS ECS Agent on Ubuntu"
   license: MIT
-  min_ansible_version: 2.2
+  min_ansible_version: 2.5
 
   platforms:
   - name: Ubuntu

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -52,21 +52,23 @@
     group=root
     mode=0644
 
-# Uncomment this if you want to operate the docker container via systemd as advised by:
+# Option 1: Use systemd to start ECS agent container
 # https://docs.aws.amazon.com/AmazonECS/latest/developerguide/example_user_data_scripts.html
-#
-# - name: create systemd docker service for ecs-agent
-#   template:
-#     src=docker-container@ecs-agent.service.j2
-#     dest=/etc/systemd/system/docker-container@ecs-agent.service
-#     owner=root
-#     group=root
-#     mode=0644
-#
-# - name: enable ecs-agent systemd service
-#   systemd:
-#     name: docker-container@ecs-agent
-#     enabled: yes
+
+- name: create systemd docker service for ecs-agent
+  template:
+    src=docker-container@ecs-agent.service.j2
+    dest=/etc/systemd/system/docker-container@ecs-agent.service
+    owner=root
+    group=root
+    mode=0644
+  when: ubuntu_ecs_agent_start_mode == "systemd"
+
+- name: enable ecs-agent systemd service
+  systemd:
+    name: docker-container@ecs-agent
+    enabled: yes
+  when: ubuntu_ecs_agent_start_mode == "systemd"
 
 # https://docs.aws.amazon.com/batch/latest/userguide/create-batch-ami.html
 - name: Remove the persistent data checkpoint file from ecs-agent
@@ -74,6 +76,7 @@
     state: absent
     path: "/var/lib/ecs/data/ecs_agent_data.json"
 
+# Option 2: manage ECS agent container with Docker natively
 - name: Configure and run the ecs-agent container
   docker_container:
     name: ecs-agent
@@ -88,3 +91,4 @@
       - /var/lib/ecs/data:/data
     env_file: /etc/default/ecs
     privileged: yes # otherwise we get: [WARN] Disabling TaskCPUMemLimit because agent /sys/fs/cgroup/systemd/ecs: read-only file system
+  when: ubuntu_ecs_agent_start_mode == "docker"

--- a/templates/docker-container@ecs-agent.service.j2
+++ b/templates/docker-container@ecs-agent.service.j2
@@ -8,12 +8,13 @@ Restart=always
 ExecStartPre=-/usr/bin/docker rm -f %i 
 ExecStart=/usr/bin/docker run --name %i \
 --restart=on-failure:10 \
---volume=/var/run:/var/run \
+--volume=/var/run/docker.sock:/var/run/docker.sock \
 --volume=/var/log/ecs/:/log \
 --volume=/var/lib/ecs/data:/data \
---volume=/etc/ecs:/etc/ecs \
 --net=host \
---env-file=/etc/ecs/ecs.config \
+--env-file=/etc/default/ecs \
+--privileged=true \
+--init \
 amazon/amazon-ecs-agent:latest
 ExecStop=/usr/bin/docker stop %i
 

--- a/templates/ecs.j2
+++ b/templates/ecs.j2
@@ -1,11 +1,11 @@
 ECS_LOGFILE=/log/ecs-agent.log
-ECS_AVAILABLE_LOGGING_DRIVERS=["json-file","awslogs"]
-ECS_DATADIR="{{ ubuntu_ecs_agent_data_path }}"
-ECS_LOGLEVEL="{{ ubuntu_ecs_agent_loglevel }}"
+ECS_AVAILABLE_LOGGING_DRIVERS={{ ubuntu_ecs_agent_logging_drivers | to_json }}
+ECS_DATADIR={{ ubuntu_ecs_agent_data_path }}
+ECS_LOGLEVEL={{ ubuntu_ecs_agent_loglevel }}
 ECS_CLUSTER="{{ ubuntu_ecs_agent_cluster_name }}"
-ECS_ENABLE_TASK_IAM_ROLE="{{ ubuntu_ecs_agent_enable_iam_role }}"
-ECS_ENABLE_TASK_IAM_ROLE_NETWORK_HOST="{{ ubuntu_ecs_agent_enable_task_iam_role_network_host }}"
+ECS_ENABLE_TASK_IAM_ROLE={{ ubuntu_ecs_agent_enable_iam_role | to_json }}
+ECS_ENABLE_TASK_IAM_ROLE_NETWORK_HOST={{ ubuntu_ecs_agent_enable_task_iam_role_network_host | to_json }}
 ECS_RESERVED_PORTS={{ ubuntu_ecs_agent_reserved_ports }}
-ECS_CONTAINER_STOP_TIMEOUT="{{ ubuntu_ecs_agent_container_stop_timeout }}"
+ECS_CONTAINER_STOP_TIMEOUT={{ ubuntu_ecs_agent_container_stop_timeout }}
 ECS_ENGINE_AUTH_TYPE={{ ubuntu_ecs_agent_auth_type }}
 ECS_ENGINE_AUTH_DATA={{ ubuntu_ecs_agent_auth_data }}


### PR DESCRIPTION
Hi,

I used your playbook to set up an 18.04 host for ECS agent and found it didn't work anymore. It seems at least with Docker 18.06 the env-file is interpreted a bit too literally, and the quotes get passed inside the environment variables. The ecs-agent parses some of the variables as JSON (like logging drivers, ports), but the strings seem to be just literal. This meant I got startup errors about being unable to stat "/data" for instance, because Go was trying to stat the directory including the quotes. Similar issues with it not being able to parse the timeout.

I've also used Ansible conditionals to select between the systemd and native Docker startup approach, rather than just having it commented. In my case I need to use the systemd approach to use some startup hooks, but found it's possibly fallen into disrepair because it lacks the privileged option so the agent can create cgroups. I've updated the template to a working state and made it a (non-default) option that can be configured with a variable. The conditional does require an Ansible bump to 2.5, not sure how offensive that is to this project.

At some point in the future it might be worth revisiting using ecs-init to do the gruntwork here, as it seems ecs-init has quasi Ubuntu compatibility and does a growing number of things...

Thanks for your efforts though!